### PR TITLE
bugfix / theme customizer fatal error

### DIFF
--- a/inc/class-tt1skin-config.php
+++ b/inc/class-tt1skin-config.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'TT1skin_Config' ) ) {
 		 */
 		public static function set_custom_colors() {
 			if ( isset( self::$skin_data->settings->color->palette ) ) {
-				$colors_array = (array) self::$skin_data->settings->color->palette;
+				$colors_array = json_decode(json_encode(self::$skin_data->settings->color->palette), true);
 				add_theme_support( 'editor-color-palette', $colors_array );
 			}
 		}


### PR DESCRIPTION
オブジェクトの配列への型変換に失敗していたために、カスタマイザーでエラーが出ていたものを修正します。